### PR TITLE
Allow users to override the server url, just like with the Dockerfile.

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -10,3 +10,4 @@ data:
   db-password: {{ required "Must provide ottertune.dbPassword" .Values.ottertune.dbPassword | quote }}
   db-key: {{ required "Must provide ottertune.dbKey" .Values.ottertune.dbKey | quote }}
   org-id: {{ required "Must provide ottertune.orgID" .Values.ottertune.orgID | quote }}
+  server-url: {{ .Values.serverUrlOverride | quote }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -69,6 +69,13 @@ spec:
               configMapKeyRef:
                 name: {{ include "..configmapName" . }}
                 key: "org-id"
+  {{- if not (empty .Values.serverUrlOverride) }}
+          - name: "OTTERTUNE_OVERRIDE_SERVER_URL"
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "..configmapName" . }}
+                key: "server-url"
+  {{- end -}}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -44,3 +44,6 @@ affinity: {}
 podAnnotations: {}
 podSecurityContext: {}
 securityContext: {}
+
+# Allow users to override the Server URL in case of on-prem deployments.
+serverUrlOverride: ""


### PR DESCRIPTION
This PR adds the ability to configure the Server Override URL, which is responsible for pointing the agent to `https://api.ottertune.com`. The Docker container already supports overriding this variable, which can be useful when you don't want to point the agent to the production endpoint.