### PR TITLE
Fix tempate name, add Postgres DB field.

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "..name" -}}
+{{- define "ottertune-agent.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "..fullname" -}}
+{{- define "ottertune-agent.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "..chart" -}}
+{{- define "ottertune-agent.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "..labels" -}}
-helm.sh/chart: {{ include "..chart" . }}
-{{ include "..selectorLabels" . }}
+{{- define "ottertune-agent.labels" -}}
+helm.sh/chart: {{ include "ottertune-agent.chart" . }}
+{{ include "ottertune-agent.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,17 +45,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "..selectorLabels" -}}
-app.kubernetes.io/name: {{ include "..name" . }}
+{{- define "ottertune-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ottertune-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "..serviceAccountName" -}}
+{{- define "ottertune-agent.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "..fullname" .) .Values.serviceAccount.name }}
+{{- default (include "ottertune-agent.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -64,8 +64,8 @@ Create the name of the service account to use
 {{/*
 Provides the name of the Configmap.
 */}}
-{{- define "..configmapName" -}}
-{{ include "..fullname" .}}-configmap
+{{- define "ottertune-agent.configmapName" -}}
+{{ include "ottertune-agent.fullname" .}}-configmap
 {{- end }}
 
 {{/*
@@ -73,7 +73,7 @@ Returns True if the user provided AWS credentials.
 Fail when secret key is set but access id isn't.
 Fail when access id is set but secret key isn't.
 */}}
-{{- define "..awsCredsEnabled" -}}
+{{- define "ottertune-agent.awsCredsEnabled" -}}
 {{- $accessID := .Values.aws.accessKeyID | trim -}}
 {{- $secretKey := .Values.aws.secretAccessKey | trim -}}
 {{- $accessIDEmpty := empty $accessID -}}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "..configmapName" . | quote }}
+  name: {{ include "ottertune-agent.configmapName" . | quote }}
   labels:
-    {{- include "..labels" . | nindent 4 }}
+    {{- include "ottertune-agent.labels" . | nindent 4 }}
 data:
   db-identifier: {{ required "Must provide ottertune.dbIdentifier" .Values.ottertune.dbIdentifier | quote }}
   db-username: {{ required "Must provide ottertune.dbUsername" .Values.ottertune.dbUsername | quote }}
@@ -11,3 +11,4 @@ data:
   db-key: {{ required "Must provide ottertune.dbKey" .Values.ottertune.dbKey | quote }}
   org-id: {{ required "Must provide ottertune.orgID" .Values.ottertune.orgID | quote }}
   server-url: {{ .Values.serverUrlOverride | quote }}
+  postgres-db-name: {{ .Values.ottertune.postgresDBName | quote }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,14 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "..fullname" . }}
+  name: {{ include "ottertune-agent.fullname" . }}
   labels:
-    {{- include "..labels" . | nindent 4 }}
+    {{- include "ottertune-agent.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "..selectorLabels" . | nindent 6 }}
+      {{- include "ottertune-agent.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -16,13 +16,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "..selectorLabels" . | nindent 8 }}
+        {{- include "ottertune-agent.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "..serviceAccountName" . }}
+      serviceAccountName: {{ include "ottertune-agent.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -36,7 +36,7 @@ spec:
           env:
           - name: "AWS_REGION"
             value: {{ required "Must provide aws.region" .Values.aws.region | quote }}
-          {{- if eq (include "..awsCredsEnabled" . ) "true" }}
+          {{- if eq (include "ottertune-agent.awsCredsEnabled" . ) "true" }}
           - name: "AWS_ACCESS_KEY_ID"
             value: {{ .Values.aws.accessKeyID | quote }}
           - name: "AWS_SECRET_ACCESS_KEY"
@@ -45,36 +45,43 @@ spec:
           - name: "OTTERTUNE_DB_IDENTIFIER"
             valueFrom:
               configMapKeyRef:
-                name: {{ include "..configmapName" . }}
+                name: {{ include "ottertune-agent.configmapName" . }}
                 key: "db-identifier"
           - name: "OTTERTUNE_DB_USERNAME"
             valueFrom:
               configMapKeyRef:
-                name: {{ include "..configmapName" . }}
+                name: {{ include "ottertune-agent.configmapName" . }}
                 key: "db-username"
           - name: "OTTERTUNE_DB_PASSWORD"
             valueFrom:
               configMapKeyRef:
-                name: {{ include "..configmapName" . }}
+                name: {{ include "ottertune-agent.configmapName" . }}
                 key: "db-password"
           - name: "OTTERTUNE_API_KEY"
             value: {{ required "Must provide ottertuneAPIKey" .Values.ottertune.apiKey | quote }}
           - name: "OTTERTUNE_DB_KEY"
             valueFrom:
               configMapKeyRef:
-                name: {{ include "..configmapName" . }}
+                name: {{ include "ottertune-agent.configmapName" . }}
                 key: "db-key"
           - name: "OTTERTUNE_ORG_ID"
             valueFrom:
               configMapKeyRef:
-                name: {{ include "..configmapName" . }}
+                name: {{ include "ottertune-agent.configmapName" . }}
                 key: "org-id"
   {{- if not (empty .Values.serverUrlOverride) }}
           - name: "OTTERTUNE_OVERRIDE_SERVER_URL"
             valueFrom:
               configMapKeyRef:
-                name: {{ include "..configmapName" . }}
+                name: {{ include "ottertune-agent.configmapName" . }}
                 key: "server-url"
+  {{- end -}}
+  {{- if not (empty .Values.ottertune.postgresDBName) }}
+          - name: "POSTGRES_OTTERTUNE_DB_NAME"
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "ottertune-agent.configmapName" . }}
+                key: "postgres-db-name"
   {{- end -}}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "..serviceAccountName" . }}
+  name: {{ include "ottertune-agent.serviceAccountName" . }}
   labels:
-    {{- include "..labels" . | nindent 4 }}
+    {{- include "ottertune-agent.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -19,6 +19,7 @@ ottertune:
   apiKey: ""
   dbKey: ""
   orgID: ""
+  postgresDBName: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This PR:

1. Adds an optional PostgresDB name field.
2. Fixes a bug with template names.

I'm not quite sure how to add support for the OpenSSL bug fix for Aurora MySQL. We don't currently have the notion of "engine type"/"dbType" in this chart. I want to think about that more before I add a fix.

For (2), the template names were all weird, starting with "..". I was initially confused about this, and assumed it was a Helm peculiarity. Then I realized I created the chart using "helm create .". The Helm CLI must be a little buggy and assume that "." is the chart name as well as the path to the directory containing the chart. Thus, the fully qualified name for the "labels" template is "<chartname>.labels", or "..labels" in my case. This PR changes the template names to use the _actual_ chart name, `ottertune-agent`.