### PR TITLE
Force replicaCount, workaround MySQL Aurora 5.6

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     {{- include "ottertune-agent.labels" . | nindent 4 }}
 spec:
+  {{- if ne ( .Values.replicaCount | int ) 1 }}
+    {{- fail "replicaCount can only be set to 1" -}}
+  {{ else }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "ottertune-agent.selectorLabels" . | nindent 6 }}
@@ -86,6 +90,10 @@ spec:
               configMapKeyRef:
                 name: {{ include "ottertune-agent.configmap-name" . | quote }}
                 key: "postgres-db-name"
+  {{- end -}}
+  {{- if eq  .Values.ottertune.engine.mysql.auroraWorkaround.enabled true }}
+          - name: "OPENSSL_CONF"
+            value: "/usr/lib/ssl/openssl_cipher1.cnf"
   {{- end -}}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,4 @@
+# At this time, replicaCount is required to always be 1.
 replicaCount: 1
 
 image:
@@ -21,6 +22,13 @@ ottertune:
   orgID: ""
   postgresDBName: ""
   apiKeyExistingSecret: ""
+
+  # To work around a bug in the OtterTune agent, we require users specify
+  # if they are using Aurora MySQL 5.6.
+  engine:
+    mysql:
+      auroraWorkaround:
+        enabled: false
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This PR requires users set `replicaCount` to `1` and inserts the fix for MySQL Aurora 5.6.

@NealKaviratna let me know if you want to chat about the `values.yml` structure. I thought a lot about the most idiomatic way to enable this particular bugfix, and this is what I came up with. The deep nesting is to help in reducing breakage with adding or removing engine parameters in the future.