### PR TITLE
fixes yaml indentation in service account example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ helm install my-release ottertune/ottertune-agent \
 
 ### Eliding AWS Credentials
 
-**This is highy recommended.** You can omit `aws.accessKeyID` and `aws.secretAccessKey` by providing a `ServiceAccount` annotation with a IAM role granting database access. AWS [offers](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)  to attach IAM roles to Kubernetes `ServiceAccount`s. This allows the OtterTune Agent to connect to AWS RDS, eliminating the need to inject credentials into the Agent's container via environment variables. You should ensure that the role has the following [permissions](https://docs.ottertune.com/info/connect-your-database-to-ottertune/add-database/agent#policies).
+**This is highy recommended.** You can omit `aws.accessKeyID` and `aws.secretAccessKey` by providing a `ServiceAccount` annotation with a IAM role granting database access. AWS [offers](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to attach IAM roles to Kubernetes `ServiceAccount`s. This allows the OtterTune Agent to connect to AWS RDS, eliminating the need to inject credentials into the Agent's container via environment variables. You should ensure that the role has the following [permissions](https://docs.ottertune.com/info/connect-your-database-to-ottertune/add-database/agent#policies).
 
 For example, if you have an IAM Role OTAgentRole, and the ARN is arn:aws:iam::123456789:role/OTAgentRole, then you should update your `my-values.yaml` file with the following block:
 
@@ -104,7 +104,7 @@ For example, if you have an IAM Role OTAgentRole, and the ARN is arn:aws:iam::12
 serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/OTAgentRole
-    name: OTAgentServiceAccount
+  name: OTAgentServiceAccount
 ```
 
 This will ensure that the agent uses this service account which should give it the necessary IAM permissions.


### PR DESCRIPTION
Before the example added the a "name" annotation to the service account and did not change the name of the service account.

# What

Fix example in `Readme.md` for using OICD based access to AWS.

# Background

Proposed change is from this:

```yaml
serviceAccount:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/OTAgentRole
    name: OTAgentServiceAccount
```
to this

```yaml
serviceAccount:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/OTAgentRole
  name: OTAgentServiceAccount
```

The former adds the name annotation to the service account the latter gives the service account the name 
`OTAgentServiceAccount` which was my expected behavior when looking at the example and copying it into my values file.
